### PR TITLE
Feature/GAME-42: Replace from score point to score mass

### DIFF
--- a/packages/client/src/pages/Game/components/CanvasComponent/CanvasComponent.controller.ts
+++ b/packages/client/src/pages/Game/components/CanvasComponent/CanvasComponent.controller.ts
@@ -5,13 +5,7 @@ import {
   START_PLAYER_RADIUS,
 } from '@/constants/game';
 
-import {
-  CameraModel,
-  EnemyStatic,
-  MapRegionModel,
-  PlayerFeatureModel,
-  PlayerModel,
-} from './models';
+import { CameraModel, EnemyStatic, MapRegionModel, PlayerModel } from './models';
 
 import { STATUS } from './interfaces/CanvasComponent.interface';
 
@@ -203,9 +197,6 @@ export class CanvasController {
         element.Status = STATUS.DEAD;
         if (target instanceof EnemyStatic) {
           target.prepareMove(element.X, element.Y);
-        }
-        if (target instanceof PlayerFeatureModel) {
-          target.Score++;
         }
       }
     }

--- a/packages/client/src/pages/Game/components/CanvasComponent/models/Player.model.ts
+++ b/packages/client/src/pages/Game/components/CanvasComponent/models/Player.model.ts
@@ -17,7 +17,7 @@ export class PlayerModel {
   }
 
   public get MyScore() {
-    return this.Player.Score;
+    return Math.round(this.Player.Radius * 10);
   }
 
   moveDivision(camera: CameraModel, mouseX: number, mouseY: number) {

--- a/packages/client/src/pages/Game/components/CanvasComponent/models/PlayerFeature.model.ts
+++ b/packages/client/src/pages/Game/components/CanvasComponent/models/PlayerFeature.model.ts
@@ -3,7 +3,6 @@ import { ICircle } from '../interfaces/CanvasComponent.interface';
 import { GameFeatureModel } from './GameFeature.model';
 
 export class PlayerFeatureModel extends GameFeatureModel {
-  public Score = 0;
   public isColliding: boolean = false;
   public collisionTime: number = 0;
   constructor(props: ICircle) {


### PR DESCRIPTION
### Какую задачу решаем

Выводить не score, а массу игрока. Таким образом игрок начинает всегда с какой то установленной массы, выводящейся на табло (вместо score). Почему? Потому что при поедании игроком врагов сейчас ничего не засчитывается (score не увеличивается). А просто добавлять в таком случае +1 очко нелогично, тк все враги имеют разные размеры, в отличии от еды. Также вирусы будут воздействовать на игроков, уменьшая их размер, а следовательно массу.

### Скриншоты/видяшка (если есть)

### TBD (если есть)