### PR TITLE
Feature/GAME-43: Add space handler = speed boost

### DIFF
--- a/packages/client/src/constants/game.ts
+++ b/packages/client/src/constants/game.ts
@@ -4,6 +4,11 @@ export const FOOD_COUNT = 5000;
 export const FOOD_MASS = 1;
 export const ENEMY_COUNT = 100;
 export const MAP_SIZE = 4000;
-export const MAX_DIVISIONS = 16;
 export const GROW_BY_FOOD_COEFFICIENT = 0.2;
 export const START_PLAYER_RADIUS = 3;
+/** в миллисекундах. Время ожидания заполнения шкалы */
+export const SPEED_BOOST_PROGRESS_INTERVAL = 60_000;
+/** в миллисекундах. Время действия шкалы */
+export const SPEED_BOOST_TIME = 2_000;
+/** коэффициент ускорения при воздействии шкалы */
+export const SPEED_BOOST_COEFFICIENT = 2;

--- a/packages/client/src/pages/Game/components/CanvasComponent/CanvasComponent.module.scss
+++ b/packages/client/src/pages/Game/components/CanvasComponent/CanvasComponent.module.scss
@@ -35,6 +35,20 @@ canvas {
       color: $color-medium-grey;
     }
   }
+
+  &__progress {
+    display: flex;
+    width: 100px;
+    height: 15px;
+    background: grey;
+    margin-top: 10px;
+    &__fill {
+      background: yellow;
+    }
+    &__complete {
+      background: green;
+    }
+  }
 }
 
 .back-button {

--- a/packages/client/src/pages/Game/components/CanvasComponent/CanvasComponent.tsx
+++ b/packages/client/src/pages/Game/components/CanvasComponent/CanvasComponent.tsx
@@ -8,7 +8,7 @@ import { CanvasController } from './CanvasComponent.controller';
 
 import styles from './CanvasComponent.module.scss';
 import { STATUS } from './interfaces/CanvasComponent.interface';
-import { Button } from 'react-bootstrap';
+import { Button, ProgressBar } from 'react-bootstrap';
 import { useSelector } from 'react-redux';
 import { RootState } from '@/redux/store';
 import { TResult } from '../../Game.interface';
@@ -29,6 +29,7 @@ export function CanvasComponent({
   const animationFrameRef = useRef<number | null>(null);
   const mouseCoodrs = useMousePosition();
   const [score, setScore] = useState(0);
+  const [progress, setProgress] = useState(0);
 
   useCanvasResize();
 
@@ -103,6 +104,7 @@ export function CanvasComponent({
     }
     setScore(controller.Player.MyScore);
 
+    setProgress(controller.Player.BoostProgress);
     const ctx = refCanvas.current.getContext('2d');
     if (!ctx) return;
     renderCanvas(ctx);
@@ -132,11 +134,7 @@ export function CanvasComponent({
 
     const cb = (event: KeyboardEvent) => {
       if (event.code === 'Space') {
-        controller.Player.cellDivision(
-          controller.Camera,
-          mouseCoodrs.current.X,
-          mouseCoodrs.current.Y,
-        );
+        controller.Player.activateSpeedBooster();
         return;
       }
       if (event.code === 'KeyW') {
@@ -162,6 +160,17 @@ export function CanvasComponent({
           <div className={styles['canvas-page__score-block__name']}>Score: </div>
           <div className={styles['canvas-page__score-block__points']}>{score}</div>
         </div>
+        <ProgressBar className={styles['canvas-page__progress']}>
+          <ProgressBar
+            className={
+              progress < 100
+                ? styles['canvas-page__progress__fill']
+                : styles['canvas-page__progress__complete']
+            }
+            now={progress}
+            max={100}
+          />
+        </ProgressBar>
         <Button
           className={styles['back-button']}
           type="button"


### PR DESCRIPTION
### Какую задачу решаем
Заменить разделение при нажатии на Space ускорением, как уже обсуждали ранее. Допустим, ускорение дается на 5сек (или больше/меньше). Можно воспользоваться только после восстановления функции (по прошествии определенного времени после использования). Логика такая: игрок начинает игру, шкала ускорения начинает заполняться, когда она заполнилась он может воспользоваться им. Восстановление, допустим, 1мин. Отрисовать таймеры рядом с другими элементами меню игры.

### Скриншоты/видяшка (если есть)

### TBD (если есть)